### PR TITLE
Add PureAnalogPin support in AdvancedADC

### DIFF
--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -20,6 +20,17 @@
 #include "Arduino.h"
 #include "HALConfig.h"
 #include "AdvancedADC.h"
+#if __has_include("pure_analog_pins.h")
+#include "pure_analog_pins.h"
+#endif
+
+#if __has_include("pure_analog_pins.h")
+template <>
+PinName AdvancedADC::_toPinName(PureAnalogPin p) {
+    extern AnalogPinDescription g_pureAAnalogPinDescription[];
+    return g_pureAAnalogPinDescription[p.get()].name;
+}
+#endif
 
 #define ADC_NP  ((ADCName) NC)
 #define ADC_PIN_ALT_MASK    (uint32_t) (ALT0 | ALT1 )
@@ -236,6 +247,23 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
 
     return 1;
 }
+
+#if __has_include("pure_analog_pins.h")
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples,
+                       size_t n_buffers, size_t n_pins, PureAnalogPin *pins,
+                       bool start, adc_sample_time_t sample_time) {
+    if (n_pins > AN_MAX_ADC_CHANNELS) {
+        n_pins = AN_MAX_ADC_CHANNELS;
+    }
+
+    for (size_t i = 0; i < n_pins; ++i) {
+        adc_pins[i] = _toPinName(pins[i]);
+    }
+
+    n_channels = n_pins;
+    return begin(resolution, sample_rate, n_samples, n_buffers, start, sample_time);
+}
+#endif
 
 int AdvancedADC::start(uint32_t sample_rate){
     // Initialize and configure the ADC timer.

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -21,6 +21,9 @@
 #define __ADVANCED_ADC_H__
 
 #include "AdvancedAnalog.h"
+#if __has_include("pure_analog_pins.h")
+#include "pure_analog_pins.h"
+#endif
 
 struct adc_descr_t;
 
@@ -41,14 +44,22 @@ class AdvancedADC {
         adc_descr_t *descr;
         PinName adc_pins[AN_MAX_ADC_CHANNELS];
 
+        template <typename P>
+        static inline PinName _toPinName(P p) {
+            return analogPinToPinName(p);
+        }
+#if __has_include("pure_analog_pins.h")
+        static PinName _toPinName(PureAnalogPin p);
+#endif
+
     public:
-        template <typename ... T>
-        AdvancedADC(pin_size_t p0, T ... args): n_channels(0), descr(nullptr) {
-            static_assert(sizeof ...(args) < AN_MAX_ADC_CHANNELS,
+        template <typename P0, typename ... P>
+        AdvancedADC(P0 p0, P ... pins): n_channels(0), descr(nullptr) {
+            static_assert(sizeof ...(pins) < AN_MAX_ADC_CHANNELS,
                     "A maximum of 16 channels can be sampled successively.");
 
-            for (auto p : {p0, args...}) {
-                adc_pins[n_channels++] = analogPinToPinName(p);
+            for (PinName pin : { _toPinName(p0), _toPinName(pins)... }) {
+                adc_pins[n_channels++] = pin;
             }
         }
         AdvancedADC(): n_channels(0), descr(nullptr) {
@@ -72,6 +83,11 @@ class AdvancedADC {
             n_channels = n_pins;
             return begin(resolution, sample_rate, n_samples, n_buffers, start, sample_time);
         }
+#if __has_include("pure_analog_pins.h")
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples,
+                  size_t n_buffers, size_t n_pins, PureAnalogPin *pins, bool start=true,
+                  adc_sample_time_t sample_time=AN_ADC_SAMPLETIME_8_5);
+#endif
         int start(uint32_t sample_rate);
         int stop();
         void clear();


### PR DESCRIPTION
## Summary
- support pure analog pins (A8-A11) in AdvancedADC
- map PureAnalogPin to PinName with specialization
- implement begin overload for arrays of PureAnalogPin

## Testing
- `codespell -q 3 --skip="./docs/api.md,./examples/*/*.wav"` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6bc6de48323b464729601050ded